### PR TITLE
Add compose-dev.yaml used by DD 4.13+

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    entrypoint:
+    - sleep
+    - infinity
+    image: docker/dev-environments-go:stable-1
+    init: true
+    volumes:
+    - type: bind
+      source: /var/run/docker.sock
+      target: /var/run/docker.sock
+


### PR DESCRIPTION
Leaving existing .docker configuration for now for compatibility with previous
releases.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
